### PR TITLE
Bump node version to 16 in gh-workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn workspace backend install
+      - run: yarn install
       - run: yarn test:backend

--- a/packages/backend/services/plausible.js
+++ b/packages/backend/services/plausible.js
@@ -4,6 +4,8 @@ const axios = require("axios");
 const PLAUSIBLE_EVENT_ENDPOINT = "https://plausible.io/api/event";
 
 const trackPlausibleEvent = async (eventName, props, request) => {
+  if (typeof jest !== "undefined") return;
+
   const payload = {
     domain: "speedrunethereum.com",
     name: eventName,


### PR DESCRIPTION
### Description 
In favor of #187 we have to update the node version to `>=16` because `@formatjs/cli@6.0.4`  requires it. checkout [failed job](https://github.com/BuidlGuidl/SpeedRunEthereum/actions/runs/4871126896/jobs/8687718506)

Even though we are doing : 
```shell
  - run: yarn workspace backend install
```
It seems that yarn first does `yarn install` which leads to installing `@formatjs/cli@6.0.4` which is being used `react-app` workspace. 

### Current approach : 
Updated the node version from `14.x` to `16.x` and also updated the run task from : 
```diff
- run: yarn workspace backend install
+ run: yarn install
```
Actually, there is no need of updating `run` task but since `yarn workspace backend install` runs `yarn install` prior updated it to only run `yarn install`. 

Found this approach minimal and working. 

### Test : 
Tired doing `yarn install` using node `v16` locally and it seems everything works. 

Also tried running gh-workflow using node v16 checkout [details here](https://github.com/technophile-04/SpeedRunEthereum/actions/runs/4907851357/jobs/8763228834?pr=1)( **Although `tests` failed but `yarn install` workded**)

### Approches explored : 
1. `yarn workspace backend install --focus`  : It seems that if you use `--focus` option it fetches from npm registry and it gives the below error : ![Screenshot 2023-05-07 at 9 23 56 PM](https://user-images.githubusercontent.com/80153681/236727006-061a9583-fa9f-4fe6-a2f6-4754a6c1b3d7.jpg) checkout the OG discussion https://github.com/yarnpkg/yarn/issues/5864 . Also I read somewhere that `--focus` is of no use if you haven't hosted packages on npm registry but couldn't find the reference now : (  
2. `yarn install --scope @scaffold-eth/monorepo/backend` : even this doesn't work : ( , it was suggested here -> https://github.com/yarnpkg/yarn/issues/6715#issuecomment-539985932
            




