### PR TITLE
fix: require Node 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "yarn"
   ],
   "private": true,
+  "engines": {
+    "node": ">=17.0.0"
+  },
   "scripts": {
     "react-app:build": "yarn workspace @scaffold-eth/react-app build --max-old-space-size=12288",
     "react-app:eject": "yarn workspace @scaffold-eth/react-app eject",


### PR DESCRIPTION
### Description
This PR fixes an issue where the `--openssl-legacy-provider` flag caused errors when running the project with Node.js versions below 17. The `openssl-legacy-provider` option is not recognized in Node.js 16 and earlier, which leads to startup failures.

### Changes
- Updated the `package.json` to specify a minimum Node.js version requirement of 17 or higher (`"engines": { "node": ">=17.0.0" }`).

### Impact
- Users will need to upgrade to Node.js 17 or higher to run the project successfully.
- This eliminates the errors related to the `--openssl-legacy-provider` flag when running `yarn start` with Node.js versions below 17.

### Testing
- Verified that the project runs successfully with Node.js 17+ after these changes.