### PR TITLE
More testnests support

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -248,13 +248,13 @@ app.post("/challenges", withAddress, async (request, response) => {
 
     const challengeIndex = getChallengeIndexFromChallengeId(challengeId);
     const contractUrlObject = new URL(contractUrl);
-    const network = contractUrlObject.host.split(".")[0];
+    const blockExplorer = contractUrlObject.host;
     const contractAddress = contractUrlObject.pathname.replace("/address/", "");
 
     axios
       .post(process.env.AUTOGRADING_SERVER, {
         challenge: challengeIndex,
-        network,
+        blockExplorer,
         address: contractAddress,
       })
       .then(async gradingResponse => {

--- a/packages/react-app/src/helpers/strings.js
+++ b/packages/react-app/src/helpers/strings.js
@@ -1,5 +1,11 @@
 // Update after merge.
-export const ALLOWED_TESTNETS = ["rinkeby", "kovan", "ropsten", "goerli", "sepolia"];
+export const VALID_BLOCK_EXPLORER_HOSTS = [
+  "sepolia.etherscan.io",
+  "sepolia-optimism.etherscan.io",
+  "sepolia.arbiscan.io",
+  "amoy.polygonscan.com",
+  "sepolia.basescan.org",
+];
 
 export const ellipsizedAddress = longAddress =>
   longAddress ? `${longAddress.slice(0, 6)}...${longAddress.slice(-4)}` : "";
@@ -31,8 +37,9 @@ export const isValidEtherscanTestnetUrl = urlText => {
     return false;
   }
 
-  const network = url.host.split(".")[0];
-  return network && ALLOWED_TESTNETS.includes(network);
+  const { host } = url;
+
+  return host && VALID_BLOCK_EXPLORER_HOSTS.includes(host);
 };
 
 export const isBoolean = val => typeof val === "boolean";

--- a/packages/react-app/src/helpers/strings.js
+++ b/packages/react-app/src/helpers/strings.js
@@ -1,11 +1,5 @@
 // Update after merge.
-export const VALID_BLOCK_EXPLORER_HOSTS = [
-  "sepolia.etherscan.io",
-  "sepolia-optimism.etherscan.io",
-  "sepolia.arbiscan.io",
-  "amoy.polygonscan.com",
-  "sepolia.basescan.org",
-];
+export const VALID_BLOCK_EXPLORER_HOSTS = ["sepolia.etherscan.io", "sepolia-optimism.etherscan.io"];
 
 export const ellipsizedAddress = longAddress =>
   longAddress ? `${longAddress.slice(0, 6)}...${longAddress.slice(-4)}` : "";


### PR DESCRIPTION
- [breaking change] sending host to auto-grader instead of network name (possibly I'll change it to network name again)
- add new testnets
- remove deprecated testnets